### PR TITLE
dependency: bump Error Prone 2.15.0 -> 2.18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
     <junit.version>5.9.2</junit.version>
     <forbiddenapis.version>3.4</forbiddenapis.version>
     <json-schema-validator.version>1.2.0</json-schema-validator.version>
-    <error-prone.version>2.15.0</error-prone.version>
+    <error-prone.version>2.18.0</error-prone.version>
     <checkerframework.version>3.27.0</checkerframework.version>
   </properties>
 


### PR DESCRIPTION
Bumps Error Prone from 2.15.0 to 2.18.0.

Suggested commit message:
```
dependency: bump Error Prone 2.15.0 -> 2.18.0

See:
- https://github.com/google/error-prone/releases/tag/v2.16
- https://github.com/google/error-prone/releases/tag/v2.17.0
- https://github.com/google/error-prone/releases/tag/v2.18.0
- https://github.com/google/error-prone/compare/v2.15.0...v2.18.0
```